### PR TITLE
Update GitHub Actions to latest approved versions

### DIFF
--- a/.github/workflows/on-issue-opened.yml
+++ b/.github/workflows/on-issue-opened.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Check if user has repository access
         id: check-repo-access
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             try {
@@ -39,7 +39,7 @@ jobs:
 
       - name: Close community issue with helpful message
         if: steps.check-repo-access.outputs.result == 'false'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const message = `Thank you for your interest in Ed-Fi!

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,12 +30,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: scorecard.sarif
           results_format: sarif
@@ -57,7 +57,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Scorecard SARIF file
           path: scorecard.sarif
@@ -65,6 +65,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: scorecard.sarif

--- a/.github/workflows/xml-validation.yml
+++ b/.github/workflows/xml-validation.yml
@@ -26,13 +26,13 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Install Poetry
       run: pipx install poetry
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: '3.12'
         cache: "poetry"
@@ -60,7 +60,7 @@ jobs:
         exit $exit_code
 
     - name: Comment on PR
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       if: always()
       with:
         script: |


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout`, `actions/setup-python`, `actions/github-script`, `actions/upload-artifact`, `github/codeql-action`, and `ossf/scorecard-action` to their latest releases per the Ed-Fi Actions allowlist.
- Note: several of these are major-version jumps (checkout v5→v7, setup-python v6→v7, github-script v7/v8→v9, upload-artifact v4→v7) since the pins were stale — please watch CI closely on this PR.
- `on-pullrequest-security.yml`'s `repository-scanner.yml@main` reference was left untouched (pinned to `@main` by design, per repo policy).

## Test plan
- [ ] Confirm all workflow runs succeed on this PR (checkout, setup-python, github-script, scorecard, codeql upload-sarif)
- [ ] Spot-check `github-script` v9 breaking changes don't affect the two scripts in `on-issue-opened.yml`
- [ ] Spot-check `upload-artifact` v7 behavior in `scorecard.yml`